### PR TITLE
feat: preserve current input method with keep

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ client_rules:
     input_method: english
 
 # Default input method when no rules match
+# Use "keep" to preserve the current input method instead
 default_input_method: english
 
 # Fcitx5 configuration
@@ -484,6 +485,22 @@ client_rules:
   # Match terminals
   - class: "^(kitty|alacritty|wezterm)$"
     input_method: english
+```
+
+### Keeping the Current Input Method
+
+Use the reserved value `keep` when a window should preserve whichever input
+method is currently active. It does not need to be declared in `input_methods`
+or `rime_schemas`.
+
+```yaml
+client_rules:
+  # Keep the current input method when switching to Chrome
+  - class: google-chrome
+    input_method: keep
+
+# Keep the current input method for every window not matched above
+default_input_method: keep
 ```
 
 ### Custom Notification Methods

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -24,6 +24,7 @@ client_rules:
     input_method: english
   - class: "^(org.telegram.desktop)$"
     input_method: chinese
+# Set this to "keep" to preserve the current input method when no rule matches.
 default_input_method: english
 fcitx5:
   enabled: true

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -230,6 +230,25 @@ client_rules:
     input_method: english
 ```
 
+### Keeping the Current Input Method
+
+Use the reserved value `keep` when a window should preserve whichever input
+method is currently active. It does not need to be declared in `input_methods`
+or `rime_schemas`.
+
+```yaml
+client_rules:
+  # Keep the current input method when switching to Chrome
+  - class: google-chrome
+    input_method: keep
+
+# Keep the current input method for every window not matched above
+default_input_method: keep
+```
+
+No input method switch or switch notification is performed when `keep` is
+selected.
+
 ### Advanced Rules
 
 #### Using Regex Patterns

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,5 +1,8 @@
 package config
 
+// KeepInputMethod is a reserved input method value that disables switching.
+const KeepInputMethod = "keep"
+
 // Config represents the application configuration
 type Config struct {
 	Version            int                `yaml:"version" json:"version"`

--- a/internal/inputmethod/switcher.go
+++ b/internal/inputmethod/switcher.go
@@ -236,13 +236,21 @@ func (s *Switcher) processWindowChange(clientInfo *ClientInfo) error {
 	// Update current client info
 	s.currentClient = clientInfo
 
-	// Get current input method status
-	currentIM := s.GetCurrent()
-
 	// Determine target input method
 	targetIM := s.getTargetInputMethod(clientInfo)
 
 	logger.Debugf("Window changed: %s - %s (address: %s)", clientInfo.Class, clientInfo.Title, clientInfo.Address)
+
+	// A keep target preserves the active input method without querying or
+	// invoking the configured input method backend.
+	if targetIM == config.KeepInputMethod {
+		logger.Debugf("Keeping current input method for: %s - %s", clientInfo.Class, clientInfo.Title)
+		return nil
+	}
+
+	// Get current input method status
+	currentIM := s.GetCurrent()
+
 	logger.Debugf("Current IM: %s -> Target IM: %s", currentIM, targetIM)
 
 	// If input method needs to be switched
@@ -458,6 +466,11 @@ func (s *Switcher) matchPattern(pattern, text string) bool {
 }
 
 func (s *Switcher) Switch(targetMethod string) error {
+	if targetMethod == config.KeepInputMethod {
+		logger.Debug("Keeping current input method")
+		return nil
+	}
+
 	if !s.config.Fcitx5.Enabled || s.fcitx5 == nil {
 		return fmt.Errorf("fcitx5 is not enabled")
 	}

--- a/internal/inputmethod/switcher_test.go
+++ b/internal/inputmethod/switcher_test.go
@@ -1,0 +1,130 @@
+package inputmethod
+
+import (
+	"testing"
+
+	"hypr-input-switcher/internal/config"
+)
+
+type recordingNotifier struct {
+	calls int
+}
+
+func (n *recordingNotifier) ShowInputMethodSwitch(string, *config.WindowInfo) {
+	n.calls++
+}
+
+func TestGetTargetInputMethod(t *testing.T) {
+	switcher := NewSwitcher(&config.Config{
+		DefaultInputMethod: "english",
+		ClientRules: []config.ClientRule{
+			{Class: "^code$", Title: `README\.md$`, InputMethod: "chinese"},
+			{Class: "^code$", InputMethod: "english"},
+			{Class: "google-chrome", InputMethod: config.KeepInputMethod},
+			{Class: "firefox", InputMethod: "japanese"},
+		},
+	})
+
+	tests := []struct {
+		name   string
+		client *ClientInfo
+		want   string
+	}{
+		{
+			name:   "first matching class and title rule wins",
+			client: &ClientInfo{Class: "code", Title: "README.md"},
+			want:   "chinese",
+		},
+		{
+			name:   "class-only rule is used when title does not match",
+			client: &ClientInfo{Class: "code", Title: "main.go"},
+			want:   "english",
+		},
+		{
+			name:   "keep rule is returned",
+			client: &ClientInfo{Class: "google-chrome", Title: "Issue 6"},
+			want:   config.KeepInputMethod,
+		},
+		{
+			name:   "regular expression rule matches",
+			client: &ClientInfo{Class: "org.mozilla.firefox", Title: "Home"},
+			want:   "japanese",
+		},
+		{
+			name:   "unmatched client uses default",
+			client: &ClientInfo{Class: "kitty", Title: "shell"},
+			want:   "english",
+		},
+		{
+			name: "nil client uses default",
+			want: "english",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := switcher.getTargetInputMethod(tt.client); got != tt.want {
+				t.Fatalf("getTargetInputMethod() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProcessWindowChangeKeepsCurrentInputMethod(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *config.Config
+		client *ClientInfo
+	}{
+		{
+			name: "keep default",
+			config: &config.Config{
+				DefaultInputMethod: config.KeepInputMethod,
+				Notifications:      config.NotificationConfig{ShowOnSwitch: true},
+			},
+			client: &ClientInfo{Address: "0x1", Class: "kitty", Title: "shell"},
+		},
+		{
+			name: "keep client rule",
+			config: &config.Config{
+				DefaultInputMethod: "english",
+				ClientRules: []config.ClientRule{
+					{Class: "google-chrome", InputMethod: config.KeepInputMethod},
+				},
+				Notifications: config.NotificationConfig{ShowOnSwitch: true},
+			},
+			client: &ClientInfo{Address: "0x2", Class: "google-chrome", Title: "Issue 6"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			switcher := NewSwitcher(tt.config)
+			switcher.currentIM = "chinese"
+			notifier := &recordingNotifier{}
+			switcher.SetNotifier(notifier)
+
+			if err := switcher.processWindowChange(tt.client); err != nil {
+				t.Fatalf("processWindowChange() error = %v", err)
+			}
+
+			if switcher.currentClient != tt.client {
+				t.Fatal("processWindowChange() did not update the current client")
+			}
+			if switcher.currentIM != "chinese" {
+				t.Fatalf("currentIM = %q, want unchanged value %q", switcher.currentIM, "chinese")
+			}
+			if notifier.calls != 0 {
+				t.Fatalf("notification calls = %d, want 0", notifier.calls)
+			}
+		})
+	}
+}
+
+func TestSwitchKeepIsNoOp(t *testing.T) {
+	switcher := NewSwitcher(&config.Config{})
+
+	if err := switcher.Switch(config.KeepInputMethod); err != nil {
+		t.Fatalf("Switch(%q) error = %v", config.KeepInputMethod, err)
+	}
+}


### PR DESCRIPTION
## Summary

- add `keep` as a reserved input method value for client rules and the default input method
- preserve the active input method without querying or invoking Fcitx5/Rime, updating switch state, or showing a switch notification
- document the new configuration and cover rule resolution and no-op behavior with tests

## Motivation

Previously, switching from a configured window to an unmatched window always applied `default_input_method`. For example, moving from Firefox while using Chinese input to an unmatched Chrome window could unexpectedly switch back to English.

The new `keep` value makes preserving the currently active input method explicit:

```yaml
client_rules:
  - class: google-chrome
    input_method: keep

default_input_method: keep
```

`keep` can be used in either location and does not need to be declared in `input_methods` or `rime_schemas`. The shipped default remains `english`, so existing behavior is unchanged unless users opt in.

## Testing

- `go test ./...`
- `git diff --check`

Closes #6
